### PR TITLE
Create background threads for input and cursor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     src/grid/terrain.cpp
     src/grid/structure.cpp
     src/grid/unit.cpp
+    src/grid/cursor.cpp
     src/game_loop/game_loop.cpp
 )
 

--- a/src/game_loop/game_loop.cpp
+++ b/src/game_loop/game_loop.cpp
@@ -1,7 +1,7 @@
 #include "../include/game_loop.hpp"
 
 // @TODO: this will need to be made into a class eventually
-void game_loop() {
+auto GameLoop() -> void {
   bool running = true;
   Grid g(84, 36);
 
@@ -10,37 +10,9 @@ void game_loop() {
   g.Draw();
   refresh();
 
-  while (running) {
-    // Process input
-    int input = getch();
-
-    switch (input) {
-    case 'q':
-      running = false;
-      break;
-    case KEY_UP:
-      g.CursorUp();
-      break;
-    case KEY_DOWN:
-      g.CursorDown();
-      break;
-    case KEY_RIGHT:
-      g.CursorRight();
-      break;
-    case KEY_LEFT:
-      g.CursorLeft();
-      break;
-    default:
-      break;
-    }
-
-    // Update game state?
-
+  while (g.IsGameRunning()) {
     // Render
     g.Draw();
     refresh();
-
-    // Simulate fixed time step (16ms, approx 60fps)
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 }

--- a/src/game_loop/game_loop.cpp
+++ b/src/game_loop/game_loop.cpp
@@ -6,13 +6,43 @@ auto GameLoop() -> void {
   Grid g(84, 36);
 
   keypad(stdscr, TRUE);
+  cbreak();
+  noecho();
+  nodelay(stdscr, TRUE); // Enable non-blocking input
 
   g.Draw();
   refresh();
 
-  while (g.IsGameRunning()) {
+  while (running) {
+    int input = getch();
+
+    if (input != ERR) {
+      switch (input) {
+      case 'q':
+        running = false;
+        break;
+      case KEY_UP:
+        g.CursorUp();
+        break;
+      case KEY_DOWN:
+        g.CursorDown();
+        break;
+      case KEY_RIGHT:
+        g.CursorRight();
+        break;
+      case KEY_LEFT:
+        g.CursorLeft();
+        break;
+      default:
+        break;
+      }
+    }
+
     // Render
     g.Draw();
     refresh();
+
+    // Simulate fixed time step (16ms, approx 60fps)
+    std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 }

--- a/src/grid/cursor.cpp
+++ b/src/grid/cursor.cpp
@@ -1,0 +1,35 @@
+#include "../include/cursor.hpp"
+#include <chrono>
+
+Cursor::Cursor() {
+  cursor_blink_background_thread_.emplace(
+      [&] { StartCursorBlinkBackgroundThread(); });
+}
+
+auto Cursor::GetBlinkState() -> bool { return blink_state_; }
+
+auto Cursor::TimeSinceEpochInMilliseconds() -> uint64_t {
+  using namespace std::chrono;
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+      .count();
+}
+
+auto Cursor::StartCursorBlinkBackgroundThread() -> void {
+  auto start = TimeSinceEpochInMilliseconds();
+
+  while (is_background_thread_running_) {
+    auto now = TimeSinceEpochInMilliseconds();
+
+    if (now - start >= cursor_blink_interval_milliseconds_) {
+      blink_state_ = !blink_state_;
+      start = now;
+    }
+  }
+}
+
+Cursor::~Cursor() {
+  is_background_thread_running_ = false;
+  if (cursor_blink_background_thread_.has_value()) {
+    cursor_blink_background_thread_->join();
+  }
+}

--- a/src/grid/cursor.cpp
+++ b/src/grid/cursor.cpp
@@ -1,5 +1,6 @@
 #include "../include/cursor.hpp"
 #include <chrono>
+#include <mutex>
 
 Cursor::Cursor() {
   cursor_blink_background_thread_.emplace(
@@ -15,16 +16,21 @@ auto Cursor::TimeSinceEpochInMilliseconds() -> uint64_t {
 }
 
 auto Cursor::StartCursorBlinkBackgroundThread() -> void {
-  auto start = TimeSinceEpochInMilliseconds();
-
   while (is_background_thread_running_) {
     auto now = TimeSinceEpochInMilliseconds();
 
-    if (now - start >= cursor_blink_interval_milliseconds_) {
+    if (now - blink_start_time_ >= cursor_blink_interval_milliseconds_) {
       blink_state_ = !blink_state_;
-      start = now;
+      blink_start_time_ = now;
     }
   }
+}
+
+auto Cursor::RefreshBlinkTimer() -> void {
+  auto now = TimeSinceEpochInMilliseconds();
+
+  blink_state_ = true;
+  blink_start_time_ = now;
 }
 
 Cursor::~Cursor() {

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <ncurses.h>
@@ -65,44 +66,6 @@ Grid::Grid(unsigned int width, unsigned int height)
   MapLibraries();
   MapTrollsDens();
   MapPits();
-
-  input_background_thread_.emplace([&]() { StartInputBackgroundThread(); });
-}
-
-Grid::~Grid() {
-  is_background_thread_running_ = false;
-  if (input_background_thread_.has_value()) {
-    input_background_thread_->join();
-  }
-}
-
-void Grid::StartInputBackgroundThread() {
-  while (is_background_thread_running_) {
-    int input = getch();
-
-    switch (input) {
-    case 'q':
-      is_game_running_ = false;
-      break;
-    case KEY_UP:
-      CursorUp();
-      break;
-    case KEY_DOWN:
-      CursorDown();
-      break;
-    case KEY_RIGHT:
-      CursorRight();
-      break;
-    case KEY_LEFT:
-      CursorLeft();
-      break;
-    default:
-      break;
-    }
-
-    // Simulate fixed time step (16ms, approx 60fps)
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
-  }
 }
 
 auto Grid::IsGameRunning() -> bool { return is_game_running_; }
@@ -110,24 +73,28 @@ auto Grid::IsGameRunning() -> bool { return is_game_running_; }
 void Grid::CursorDown() {
   if (cursor_.y + 1 < height_) {
     cursor_.y++;
+    cursor_.RefreshBlinkTimer();
   }
 }
 
 void Grid::CursorUp() {
   if (cursor_.y - 1 >= 0) {
     cursor_.y--;
+    cursor_.RefreshBlinkTimer();
   }
 }
 
 void Grid::CursorLeft() {
   if (cursor_.x - 1 >= 0) {
     cursor_.x--;
+    cursor_.RefreshBlinkTimer();
   }
 }
 
 void Grid::CursorRight() {
   if (cursor_.x + 1 < width_) {
     cursor_.x++;
+    cursor_.RefreshBlinkTimer();
   }
 }
 

--- a/src/include/cursor.hpp
+++ b/src/include/cursor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <optional>
 #include <thread>
 
@@ -12,6 +13,7 @@ public:
   int y = 0;
 
   auto GetBlinkState() -> bool;
+  auto RefreshBlinkTimer() -> void;
 
 private:
   /**
@@ -20,7 +22,8 @@ private:
    * false = OFF.
    */
   bool blink_state_ = true;
-  int cursor_blink_interval_milliseconds_ = 200;
+  int cursor_blink_interval_milliseconds_ = 300;
+  uint64_t blink_start_time_ = 0;
 
   /** The background thread responsible for blinking the cursor on and off. */
   std::optional<std::thread> cursor_blink_background_thread_;

--- a/src/include/cursor.hpp
+++ b/src/include/cursor.hpp
@@ -1,6 +1,33 @@
 #pragma once
 
-struct Cursor {
+#include <optional>
+#include <thread>
+
+class Cursor {
+public:
+  Cursor();
+  ~Cursor();
+
   int x = 0;
   int y = 0;
+
+  auto GetBlinkState() -> bool;
+
+private:
+  /**
+   * Blink state of the cursor.
+   * true = ON.
+   * false = OFF.
+   */
+  bool blink_state_ = true;
+  int cursor_blink_interval_milliseconds_ = 200;
+
+  /** The background thread responsible for blinking the cursor on and off. */
+  std::optional<std::thread> cursor_blink_background_thread_;
+  /** Used to terminate the background thread upon destruction. */
+  bool is_background_thread_running_ = true;
+
+  auto StartCursorBlinkBackgroundThread() -> void;
+
+  auto TimeSinceEpochInMilliseconds() -> uint64_t;
 };

--- a/src/include/game_loop.hpp
+++ b/src/include/game_loop.hpp
@@ -6,4 +6,4 @@
 #include <ncurses.h>
 #include <thread>
 
-void game_loop();
+auto GameLoop() -> void;

--- a/src/include/grid.hpp
+++ b/src/include/grid.hpp
@@ -12,9 +12,13 @@
 class Grid {
 public:
   Grid(unsigned int width, unsigned int height);
-  ~Grid();
   auto Draw() -> void;
   auto IsGameRunning() -> bool;
+
+  auto CursorUp() -> void;
+  auto CursorDown() -> void;
+  auto CursorLeft() -> void;
+  auto CursorRight() -> void;
 
 private:
   unsigned int width_;
@@ -31,18 +35,6 @@ private:
   HeatMap terrain_heatmap_;
 
   bool is_game_running_ = true;
-
-  /** Background thread responsible for handling user input. */
-  std::optional<std::thread> input_background_thread_;
-  /** Used to terminate the background thread upon destruction. */
-  bool is_background_thread_running_ = true;
-
-  auto StartInputBackgroundThread() -> void;
-
-  auto CursorUp() -> void;
-  auto CursorDown() -> void;
-  auto CursorLeft() -> void;
-  auto CursorRight() -> void;
 
   auto MapBasicTerrain() -> void;
   auto MapDesertTerrain() -> void;

--- a/src/include/grid.hpp
+++ b/src/include/grid.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include <cstdint>
+#include <optional>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -10,11 +12,9 @@
 class Grid {
 public:
   Grid(unsigned int width, unsigned int height);
+  ~Grid();
   auto Draw() -> void;
-  auto CursorUp() -> void;
-  auto CursorDown() -> void;
-  auto CursorLeft() -> void;
-  auto CursorRight() -> void;
+  auto IsGameRunning() -> bool;
 
 private:
   unsigned int width_;
@@ -29,6 +29,20 @@ private:
   uint8_t selected_colour_pair_ = 1;
 
   HeatMap terrain_heatmap_;
+
+  bool is_game_running_ = true;
+
+  /** Background thread responsible for handling user input. */
+  std::optional<std::thread> input_background_thread_;
+  /** Used to terminate the background thread upon destruction. */
+  bool is_background_thread_running_ = true;
+
+  auto StartInputBackgroundThread() -> void;
+
+  auto CursorUp() -> void;
+  auto CursorDown() -> void;
+  auto CursorLeft() -> void;
+  auto CursorRight() -> void;
 
   auto MapBasicTerrain() -> void;
   auto MapDesertTerrain() -> void;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ int main() {
 
   start_color();
 
-  game_loop();
+  GameLoop();
 
   endwin();
 


### PR DESCRIPTION
- Moved cursor blink into its own background thread.
- Fixed use of `getch()` function -> it now no longer blocks the main thread. 